### PR TITLE
GPX-Track: Ort-Koordinaten automatisch übernehmen

### DIFF
--- a/TripPlanner.Web/Components/Shared/PlaceDialog.razor
+++ b/TripPlanner.Web/Components/Shared/PlaceDialog.razor
@@ -285,6 +285,8 @@
 
                 // Link it to the place
                 Content.GpxTrackId = gpxTrack.Id;
+                Content.Latitude = gpxTrack.Points.FirstOrDefault()?.Latitude ?? Content.Latitude;
+                Content.Longitude = gpxTrack.Points.FirstOrDefault()?.Longitude ?? Content.Longitude;
 
                 // Reload GPX tracks
                 await LoadGpxTracks();


### PR DESCRIPTION
Nach dem Speichern eines GPX-Tracks werden die Latitude und Longitude des zugehörigen Ortes automatisch auf die Werte des ersten GPX-Punktes gesetzt, sofern vorhanden. Andernfalls bleiben die bisherigen Koordinaten erhalten.