### PR TITLE
Set PageTitle on trip planning page

### DIFF
--- a/TripPlanner.Web/Components/Pages/Trips/TripPlanPage.razor
+++ b/TripPlanner.Web/Components/Pages/Trips/TripPlanPage.razor
@@ -18,6 +18,8 @@
 
 @rendermode InteractiveServer
 
+<PageTitle>Trip Planner - @(PlanningTrip?.Name ?? TripId)</PageTitle>
+
 <FluentGrid Spacing="3">
     @if (PlanningTrip != null)
     {


### PR DESCRIPTION
This pull request makes a small improvement to the `TripPlanPage.razor` component by adding a dynamic page title that reflects the current trip's name or ID. This enhances the user experience by providing more relevant information in the browser tab.