### PR TITLE
Map/public collection token

### DIFF
--- a/TripPlanner.Web/Components/Pages/Collections/CollectionDetailPage.razor
+++ b/TripPlanner.Web/Components/Pages/Collections/CollectionDetailPage.razor
@@ -44,6 +44,9 @@ else if (_collection != null)
                 <FluentButton Appearance="Appearance.Lightweight" IconStart="@(new Icons.Regular.Size20.Copy())" OnClick="@CopyPublicLink" title="Copy public link">
                     Copy Link
                 </FluentButton>
+                <FluentButton Appearance="Appearance.Lightweight" IconStart="@(new Icons.Regular.Size20.Copy())" OnClick="@CopyPublicMapLink" title="Copy public map link">
+                    Copy Map Link
+                </FluentButton>
                 <FluentButton Appearance="Appearance.Lightweight" IconStart="@(new Icons.Regular.Size20.LinkDismiss())" OnClick="@RevokePublicLink" title="Revoke public link">
                     Revoke Link
                 </FluentButton>
@@ -172,6 +175,23 @@ else if (_collection != null)
     {
         if (_collection?.PublicShareToken == null) return;
         var url = NavigationManager.ToAbsoluteUri($"/share/collection/{_collection.PublicShareToken}").ToString();
+        try
+        {
+            await JS.InvokeVoidAsync("navigator.clipboard.writeText", url);
+            _statusMessage = "Link copied to clipboard!";
+            _statusIntent = MessageIntent.Success;
+        }
+        catch
+        {
+            _statusMessage = $"Could not copy to clipboard. Copy manually: {url}";
+            _statusIntent = MessageIntent.Warning;
+        }
+    }
+
+    private async Task CopyPublicMapLink()
+    {
+        if (_collection?.PublicShareToken == null) return;
+        var url = NavigationManager.ToAbsoluteUri($"/map?CollectionToken={_collection.PublicShareToken}").ToString();
         try
         {
             await JS.InvokeVoidAsync("navigator.clipboard.writeText", url);

--- a/TripPlanner.Web/Components/Pages/Map/MapPage.razor
+++ b/TripPlanner.Web/Components/Pages/Map/MapPage.razor
@@ -75,7 +75,8 @@
                                       OnCardUnhovered="@(() => OnCardUnhovered(place.Id))"
                                       OnSetImageIndex="@((idx) => SetImageIndex(place.Id, idx))"
                                       OnImageClick="@((idx) => OpenImageLightbox(place, idx))"
-                                      OnAddToCollection="@ShowAddToCollectionDialog" />
+                                      OnAddToCollection="@ShowAddToCollectionDialog"
+                                      PublicToken="@CollectionToken" />
                     }
                 </FluentStack>
             }
@@ -94,7 +95,8 @@
                                       OnCardHovered="@(() => OnCardHovered(place.Id))"
                                       OnCardUnhovered="@(() => OnCardUnhovered(place.Id))"
                                       OnSetImageIndex="@((idx) => SetImageIndex(place.Id, idx))"
-                                      OnImageClick="@((idx) => OpenImageLightbox(place, idx))" />
+                                      OnImageClick="@((idx) => OpenImageLightbox(place, idx))"
+                                      PublicToken="@CollectionToken" />
                     }
                 </FluentHorizontalScroll>
             }
@@ -116,7 +118,8 @@
                                   OnCardHovered="@(() => OnCardHovered(tripPlace.Place.Id))"
                                   OnCardUnhovered="@(() => OnCardUnhovered(tripPlace.Place.Id))"
                                   OnSetImageIndex="@((idx) => SetImageIndex(tripPlace.Place.Id, idx))"
-                                  OnImageClick="@((idx) => OpenImageLightbox(tripPlace.Place, idx))" />
+                                  OnImageClick="@((idx) => OpenImageLightbox(tripPlace.Place, idx))"
+                                  PublicToken="@CollectionToken" />
                 }
             }
         </FluentStack>
@@ -127,7 +130,8 @@
         <PlaceLightbox Place="@_lightboxPlace"
                        InitialIndex="@_lightboxImageIndex"
                        IsOpen="@_lightboxOpen"
-                       IsOpenChanged="@OnLightboxIsOpenChanged" />
+                       IsOpenChanged="@OnLightboxIsOpenChanged"
+                       PublicToken="@CollectionToken" />
     }
 
 </div>

--- a/TripPlanner.Web/Components/Pages/Map/MapPage.razor
+++ b/TripPlanner.Web/Components/Pages/Map/MapPage.razor
@@ -303,11 +303,9 @@
         }
         else
         {
-            Places = (await CollectionRepository.GetByPublicTokenAsync(CollectionToken!))?.Items
-                .Where(ci => ci.Place is not null)
-                .Select(ci => ci.Place!)
+            Places = (await CollectionRepository.GetPlacesByPublicTokenAsync(CollectionToken!))
                 .Where(x => x.Latitude != 0 && x.Longitude != 0)
-                .ToList() ?? [];
+                .ToList();
 
         }
         

--- a/TripPlanner.Web/Components/Pages/Map/MapPage.razor
+++ b/TripPlanner.Web/Components/Pages/Map/MapPage.razor
@@ -12,12 +12,11 @@
 @inject IPlaceRepository PlaceRepository
 @inject ITripRepository TripRepository
 @inject IGpxRepository GpxRepository
+@inject IPlaceCollectionRepository CollectionRepository
 @inject IJSRuntime JSRuntime
 @inject UserService UserService
 @inject IDialogService DialogService
 @inject WeatherService WeatherService
-
-@attribute [Authorize]
 
 @implements IAsyncDisposable
 
@@ -28,7 +27,8 @@
 <div id="map-container" style="width: 100%; height: 100%;">
     <div id="map" style="height:100%; width:100%;"></div>
 
-        <FluentToolbar style="position: absolute; top: 6px; left: 6px; max-width: calc(100% - min(320px, 50%) - 18px); max-height: 25%;">
+    <FluentToolbar style="position: absolute; top: 6px; left: 6px; max-width: calc(100% - min(320px, 50%) - 18px); max-height: 25%;">
+        @if(string.IsNullOrEmpty(CollectionToken)) {
             <FluentSelect TOption="string" @bind-Value="@SelectedTripId" Style="width:100%; min-width:50px;" AriaLabel="Select Trip">
                 <FluentOption TOption="string" Value="@string.Empty">All Trips</FluentOption>
                 @foreach (var trip in Trips)
@@ -36,90 +36,91 @@
                     <FluentOption TOption="string" Value="@trip.Id">@trip.Name</FluentOption>
                 }
             </FluentSelect>
-            <FluentSelect TOption="string" Value="@SelectedWeatherDayStr" ValueChanged="@OnWeatherDayChanged" Disabled="@(!ShowWeather)" Style="width:100%; min-width:50px;" AriaLabel="Select Weather Day">
-                @for (int i = 0; i < 7; i++)
-                {
-                    var day = i;
-                    var date = DateTime.Today.AddDays(day);
-                    var label = day == 0 ? "Today" : day == 1 ? "Tomorrow" : date.ToString("ddd, MMM d");
-                    <FluentOption TOption="string" Value="@day.ToString()">@label</FluentOption>
-                }
-            </FluentSelect>
-
-            <FluentButton Appearance="Appearance.Outline" IconStart="@(new Icons.Regular.Size20.ArrowSync())" OnClick="@LoadMapData" aria-label="refresh map" />
-            <FluentButton Appearance="@(ShowWishlist ? Appearance.Accent : Appearance.Outline)" IconStart="@(new Icons.Regular.Size20.Heart())" OnClick="@(() => ShowWishlist = !ShowWishlist)" aria-label="toggle show wishlist" />
-            <FluentButton Appearance="@(ShowGpxTracks ? Appearance.Accent : Appearance.Outline)" IconStart="@(new Icons.Regular.Size20.MountainTrail())" OnClick="@(() => ShowGpxTracks = !ShowGpxTracks)" aria-label="toggle show gpx tracks" />
-            <FluentButton Appearance="@(ShowRoutes ? Appearance.Accent : Appearance.Outline)" IconStart="@(new Icons.Regular.Size20.Road())" OnClick="@(() => ShowRoutes = !ShowRoutes)" aria-label="toggle show routes" />
-            <FluentButton Appearance="@(ShowWeather ? Appearance.Accent : Appearance.Outline)" IconStart="@(new Icons.Regular.Size20.WeatherHailDay())" OnClick="@(() => ShowWeather = !ShowWeather)" aria-label="toggle show weather" />
-        </FluentToolbar>
-
-
-        <!-- Side Panel -->
-        <div style="@SidePanelStyle">
-
-            @if (ShowWishlist)
+        }
+        <FluentSelect TOption="string" Value="@SelectedWeatherDayStr" ValueChanged="@OnWeatherDayChanged" Disabled="@(!ShowWeather)" Style="width:100%; min-width:50px;" AriaLabel="Select Weather Day">
+            @for (int i = 0; i < 7; i++)
             {
-                @if (isLandscape)
+                var day = i;
+                var date = DateTime.Today.AddDays(day);
+                var label = day == 0 ? "Today" : day == 1 ? "Tomorrow" : date.ToString("ddd, MMM d");
+                <FluentOption TOption="string" Value="@day.ToString()">@label</FluentOption>
+            }
+        </FluentSelect>
+
+        <FluentButton Appearance="Appearance.Outline" IconStart="@(new Icons.Regular.Size20.ArrowSync())" OnClick="@LoadMapData" aria-label="refresh map" />
+        <FluentButton Appearance="@(ShowWishlist ? Appearance.Accent : Appearance.Outline)" IconStart="@(new Icons.Regular.Size20.Heart())" OnClick="@(() => ShowWishlist = !ShowWishlist)" aria-label="toggle show wishlist" />
+        <FluentButton Appearance="@(ShowGpxTracks ? Appearance.Accent : Appearance.Outline)" IconStart="@(new Icons.Regular.Size20.MountainTrail())" OnClick="@(() => ShowGpxTracks = !ShowGpxTracks)" aria-label="toggle show gpx tracks" />
+        <FluentButton Appearance="@(ShowRoutes ? Appearance.Accent : Appearance.Outline)" IconStart="@(new Icons.Regular.Size20.Road())" OnClick="@(() => ShowRoutes = !ShowRoutes)" aria-label="toggle show routes" />
+        <FluentButton Appearance="@(ShowWeather ? Appearance.Accent : Appearance.Outline)" IconStart="@(new Icons.Regular.Size20.WeatherHailDay())" OnClick="@(() => ShowWeather = !ShowWeather)" aria-label="toggle show weather" />
+    </FluentToolbar>
+
+
+    <!-- Side Panel -->
+    <div style="@SidePanelStyle">
+
+        @if (ShowWishlist)
+        {
+            @if (isLandscape)
+            {
+                <FluentStack Orientation="Orientation.Vertical" Style="max-height:100%;">
+                    @foreach (var place in VisibleWishlistPlaces)
+                    {
+                        <MapPlaceCard Place="@place"
+                                      IsHighlighted="@(_selectedPlaceId == place.Id || _hoveredPlaceId == place.Id)"
+                                      ShowWeather="@ShowWeather"
+                                      Weather="@WeatherByPlaceId.GetValueOrDefault(place.Id)"
+                                      CurrentImageIndex="@_currentImageIndex.GetValueOrDefault(place.Id, 0)"
+                                      OnCardClicked="@(() => OnCardClicked(place.Id))"
+                                      OnCardHovered="@(() => OnCardHovered(place.Id))"
+                                      OnCardUnhovered="@(() => OnCardUnhovered(place.Id))"
+                                      OnSetImageIndex="@((idx) => SetImageIndex(place.Id, idx))"
+                                      OnImageClick="@((idx) => OpenImageLightbox(place, idx))"
+                                      OnAddToCollection="@ShowAddToCollectionDialog" />
+                    }
+                </FluentStack>
+            }
+            else
+            {
+                <FluentHorizontalScroll Speed="600" Easing=ScrollEasing.EaseInOut>
+                    @foreach (var place in VisibleWishlistPlaces)
+                    {
+                        <MapPlaceCard Place="@place"
+                                      IsHighlighted="@(_selectedPlaceId == place.Id || _hoveredPlaceId == place.Id)"
+                                      ShowWeather="@ShowWeather"
+                                      Weather="@WeatherByPlaceId.GetValueOrDefault(place.Id)"
+                                      CurrentImageIndex="@_currentImageIndex.GetValueOrDefault(place.Id, 0)"
+                                      Compact="true"
+                                      OnCardClicked="@(() => OnCardClicked(place.Id))"
+                                      OnCardHovered="@(() => OnCardHovered(place.Id))"
+                                      OnCardUnhovered="@(() => OnCardUnhovered(place.Id))"
+                                      OnSetImageIndex="@((idx) => SetImageIndex(place.Id, idx))"
+                                      OnImageClick="@((idx) => OpenImageLightbox(place, idx))" />
+                    }
+                </FluentHorizontalScroll>
+            }
+        }
+
+        <FluentStack Orientation="Orientation.Vertical">
+            @foreach (var tripPlace in VisibleTripPlaces)
+            {
+                @if (tripPlace.Place != null)
                 {
-                    <FluentStack Orientation="Orientation.Vertical" Style="max-height:100%;">
-                        @foreach (var place in VisibleWishlistPlaces)
-                        {
-                            <MapPlaceCard Place="@place"
-                                          IsHighlighted="@(_selectedPlaceId == place.Id || _hoveredPlaceId == place.Id)"
-                                          ShowWeather="@ShowWeather"
-                                          Weather="@WeatherByPlaceId.GetValueOrDefault(place.Id)"
-                                          CurrentImageIndex="@_currentImageIndex.GetValueOrDefault(place.Id, 0)"
-                                          OnCardClicked="@(() => OnCardClicked(place.Id))"
-                                          OnCardHovered="@(() => OnCardHovered(place.Id))"
-                                          OnCardUnhovered="@(() => OnCardUnhovered(place.Id))"
-                                          OnSetImageIndex="@((idx) => SetImageIndex(place.Id, idx))"
-                                          OnImageClick="@((idx) => OpenImageLightbox(place, idx))"
-                                          OnAddToCollection="@ShowAddToCollectionDialog" />
-                        }
-                    </FluentStack>
-                }
-                else
-                {
-                    <FluentHorizontalScroll Speed="600" Easing=ScrollEasing.EaseInOut>
-                        @foreach (var place in VisibleWishlistPlaces)
-                        {
-                            <MapPlaceCard Place="@place"
-                                          IsHighlighted="@(_selectedPlaceId == place.Id || _hoveredPlaceId == place.Id)"
-                                          ShowWeather="@ShowWeather"
-                                          Weather="@WeatherByPlaceId.GetValueOrDefault(place.Id)"
-                                          CurrentImageIndex="@_currentImageIndex.GetValueOrDefault(place.Id, 0)"
-                                          Compact="true"
-                                          OnCardClicked="@(() => OnCardClicked(place.Id))"
-                                          OnCardHovered="@(() => OnCardHovered(place.Id))"
-                                          OnCardUnhovered="@(() => OnCardUnhovered(place.Id))"
-                                          OnSetImageIndex="@((idx) => SetImageIndex(place.Id, idx))"
-                                          OnImageClick="@((idx) => OpenImageLightbox(place, idx))" />
-                        }
-                    </FluentHorizontalScroll>
+                    <MapPlaceCard Place="@tripPlace.Place"
+                                  IsHighlighted="@(_selectedPlaceId == tripPlace.Place.Id || _hoveredPlaceId == tripPlace.Place.Id)"
+                                  ShowWeather="@ShowWeather"
+                                  Weather="@WeatherByPlaceId.GetValueOrDefault(tripPlace.Place.Id)"
+                                  ScheduledTime="@tripPlace.ScheduledTime"
+                                  ShowCategory="false"
+                                  CurrentImageIndex="@_currentImageIndex.GetValueOrDefault(tripPlace.Place.Id, 0)"
+                                  OnCardClicked="@(() => OnCardClicked(tripPlace.Place.Id))"
+                                  OnCardHovered="@(() => OnCardHovered(tripPlace.Place.Id))"
+                                  OnCardUnhovered="@(() => OnCardUnhovered(tripPlace.Place.Id))"
+                                  OnSetImageIndex="@((idx) => SetImageIndex(tripPlace.Place.Id, idx))"
+                                  OnImageClick="@((idx) => OpenImageLightbox(tripPlace.Place, idx))" />
                 }
             }
-
-            <FluentStack Orientation="Orientation.Vertical">
-                @foreach (var tripPlace in VisibleTripPlaces)
-                {
-                    @if (tripPlace.Place != null)
-                    {
-                        <MapPlaceCard Place="@tripPlace.Place"
-                                      IsHighlighted="@(_selectedPlaceId == tripPlace.Place.Id || _hoveredPlaceId == tripPlace.Place.Id)"
-                                      ShowWeather="@ShowWeather"
-                                      Weather="@WeatherByPlaceId.GetValueOrDefault(tripPlace.Place.Id)"
-                                      ScheduledTime="@tripPlace.ScheduledTime"
-                                      ShowCategory="false"
-                                      CurrentImageIndex="@_currentImageIndex.GetValueOrDefault(tripPlace.Place.Id, 0)"
-                                      OnCardClicked="@(() => OnCardClicked(tripPlace.Place.Id))"
-                                      OnCardHovered="@(() => OnCardHovered(tripPlace.Place.Id))"
-                                      OnCardUnhovered="@(() => OnCardUnhovered(tripPlace.Place.Id))"
-                                      OnSetImageIndex="@((idx) => SetImageIndex(tripPlace.Place.Id, idx))"
-                                      OnImageClick="@((idx) => OpenImageLightbox(tripPlace.Place, idx))" />
-                    }
-                }
-            </FluentStack>
-        </div>
+        </FluentStack>
+    </div>
 
     @if (_lightboxPlace is not null)
     {
@@ -129,7 +130,7 @@
                        IsOpenChanged="@OnLightboxIsOpenChanged" />
     }
 
-    </div>
+</div>
 
 @code {
     private List<Place> Places { get; set; } = new();
@@ -149,6 +150,9 @@
     private Dictionary<string, DailyWeather> WeatherByPlaceId { get; set; } = new();
     private CancellationTokenSource? _weatherCts;
     private bool ShowWeather { get; set; } = true;
+
+    [Parameter, SupplyParameterFromQuery]
+    public string? CollectionToken { get; set; }
 
     private string SidePanelStyle => "position: absolute;" + (
         isLandscape ?
@@ -261,35 +265,48 @@
 
         CurrentUser = await UserService.GetCurrentUserAsync();
 
-        if (CurrentUser is not null)
+        if (string.IsNullOrEmpty(CollectionToken))
         {
-            Places = (await PlaceRepository.GetAllByUserAsync(CurrentUser.Id)).Where(x => x.Latitude != 0 && x.Longitude != 0).ToList();
-            var ownedTrips = await TripRepository.GetByOwnerAsync(CurrentUser.Id);
-            var sharedTrips = await TripRepository.GetSharedWithUserAsync(CurrentUser.Id);
-            Trips = ownedTrips.UnionBy(sharedTrips, t => t.Id).ToList();
-            GpxTracks = await GpxRepository.GetAllByUserAsync(CurrentUser.Id);
-        }
-        
-        if (!string.IsNullOrEmpty(SelectedTripId))
-        {
-            var selectedTrip = Trips.FirstOrDefault(t => t.Id == SelectedTripId);
-            if (selectedTrip != null)
+            if (CurrentUser is not null)
             {
-                SelectedTripPlaces = selectedTrip.Days
-                    .SelectMany(d => d.Places)
-                    .ToList();
-                
-                // Load place details
-                foreach (var tripPlace in SelectedTripPlaces)
+                    Places = (await PlaceRepository.GetAllByUserAsync(CurrentUser.Id)).Where(x => x.Latitude != 0 && x.Longitude != 0).ToList();
+                    var ownedTrips = await TripRepository.GetByOwnerAsync(CurrentUser.Id);
+                    var sharedTrips = await TripRepository.GetSharedWithUserAsync(CurrentUser.Id);
+                    Trips = ownedTrips.UnionBy(sharedTrips, t => t.Id).ToList();
+                    GpxTracks = await GpxRepository.GetAllByUserAsync(CurrentUser.Id);
+            }
+
+            if (!string.IsNullOrEmpty(SelectedTripId))
+            {
+                var selectedTrip = Trips.FirstOrDefault(t => t.Id == SelectedTripId);
+                if (selectedTrip != null)
                 {
-                    tripPlace.Place = Places.FirstOrDefault(p => p.Id == tripPlace.PlaceId);
+                    SelectedTripPlaces = selectedTrip.Days
+                        .SelectMany(d => d.Places)
+                        .ToList();
+                
+                    // Load place details
+                    foreach (var tripPlace in SelectedTripPlaces)
+                    {
+                        tripPlace.Place = Places.FirstOrDefault(p => p.Id == tripPlace.PlaceId);
+                    }
                 }
+            }
+            else
+            {
+                SelectedTripPlaces.Clear();
             }
         }
         else
         {
-            SelectedTripPlaces.Clear();
+            Places = (await CollectionRepository.GetByPublicTokenAsync(CollectionToken!))?.Items
+                .Where(ci => ci.Place is not null)
+                .Select(ci => ci.Place!)
+                .Where(x => x.Latitude != 0 && x.Longitude != 0)
+                .ToList() ?? [];
+
         }
+        
         
         IsLoading = false;
         InvalidateVisiblePlaces();

--- a/TripPlanner.Web/Components/Pages/Map/MapPlaceCard.razor
+++ b/TripPlanner.Web/Components/Pages/Map/MapPlaceCard.razor
@@ -19,7 +19,7 @@
                             @onclick="@(() => OnImageClick.InvokeAsync(CurrentImageIndex))"
                             aria-label="@($"View images of {Place.Name}")">
                         <img @key="@CurrentImage"
-                             src="/api/placeImages/@CurrentImage?width=400"
+                             src="@ImageSrc(CurrentImage)"
                              alt="@Place.Name"
                              class="map-card-image" />
                     </button>
@@ -54,8 +54,8 @@
                             @onclick="@(() => OnImageClick.InvokeAsync(CurrentImageIndex))"
                             aria-label="@($"View images of {Place.Name}")">
                         <img @key="@CurrentImage"
-                             src="/api/placeImages/@CurrentImage?width=400"
-                             srcset="@PlaceImageHelper.BuildSrcSet(CurrentImage)"
+                             src="@ImageSrc(CurrentImage)"
+                             srcset="@PlaceImageHelper.BuildSrcSet(CurrentImage, PublicToken)"
                              sizes="(max-width: 768px) 100vw, 400px"
                              alt="@Place.Name"
                              class="map-card-image" />
@@ -96,7 +96,7 @@
                 {
                     <FluentLabel Style="font-size: 0.875em;">
                         🏔 @($"{Place.GpxTrack.TotalDistance:F1} km ↑{Place.GpxTrack.ElevationGain:F0} m")
-                        &nbsp;<a href="/api/gpx/@Place.GpxTrackId" download @onclick:stopPropagation="true" title="GPX herunterladen" style="font-size: 0.85em;">⬇ GPX</a>
+                        &nbsp;<a href="@GpxDownloadUrl" download @onclick:stopPropagation="true" title="GPX herunterladen" style="font-size: 0.85em;">⬇ GPX</a>
                     </FluentLabel>
                 }
                 @if (ShowWeather && Weather != null)
@@ -134,6 +134,9 @@
 
     [Parameter] public EventCallback<Place> OnAddToCollection { get; set; }
 
+    /// <summary>Public share token for anonymous collection access. When set, appended to image and GPX URLs.</summary>
+    [Parameter] public string? PublicToken { get; set; }
+
     private string _googleMapsUrl =>
         $"https://www.google.com/maps?q={Place.Latitude.ToString("F6", CultureInfo.InvariantCulture)},{Place.Longitude.ToString("F6", CultureInfo.InvariantCulture)}";
 
@@ -141,6 +144,13 @@
 
     private string? CurrentImage =>
         _imageCount > 0 ? Place.ImageIds[Math.Clamp(CurrentImageIndex, 0, _imageCount - 1)] : null;
+
+    private string ImageSrc(string imageId) => PlaceImageHelper.BuildSrc(imageId, 400, PublicToken);
+
+    private string GpxDownloadUrl =>
+        string.IsNullOrWhiteSpace(PublicToken)
+            ? $"/api/gpx/{Place.GpxTrackId}"
+            : $"/api/gpx/{Place.GpxTrackId}?token={Uri.EscapeDataString(PublicToken)}";
 
     private async Task AddToCollectionClicked()
     {

--- a/TripPlanner.Web/Components/Pages/Map/MapPlaceCard.razor
+++ b/TripPlanner.Web/Components/Pages/Map/MapPlaceCard.razor
@@ -147,11 +147,16 @@
 
     private string ImageSrc(string imageId) => PlaceImageHelper.BuildSrc(imageId, 400, PublicToken);
 
-    private string GpxDownloadUrl =>
-        string.IsNullOrWhiteSpace(PublicToken)
-            ? $"/api/gpx/{Place.GpxTrackId}"
-            : $"/api/gpx/{Place.GpxTrackId}?token={Uri.EscapeDataString(PublicToken)}";
+    private string GpxDownloadUrl => BuildGpxDownloadUrl();
 
+    private string BuildGpxDownloadUrl()
+    {
+        var baseUrl = $"/api/gpx/{Place.GpxTrackId}";
+
+        return string.IsNullOrWhiteSpace(PublicToken)
+            ? baseUrl
+            : $"{baseUrl}?token={Uri.EscapeDataString(PublicToken)}";
+    }
     private async Task AddToCollectionClicked()
     {
         await OnAddToCollection.InvokeAsync(Place);

--- a/TripPlanner.Web/Components/Shared/PlaceImageHelper.cs
+++ b/TripPlanner.Web/Components/Shared/PlaceImageHelper.cs
@@ -8,21 +8,29 @@ namespace TripPlanner.Web.Components.Shared;
 internal static class PlaceImageHelper
 {
     /// <summary>
+    /// Returns the src attribute value for a single place image at the given width.
+    /// When a public share token is provided it is appended for anonymous access.
+    /// </summary>
+    public static string BuildSrc(string imageId, int width, string? publicToken = null)
+    {
+        var tokenParam = string.IsNullOrWhiteSpace(publicToken) ? string.Empty : $"&token={Uri.EscapeDataString(publicToken)}";
+        return $"/api/placeImages/{imageId}?width={width}{tokenParam}";
+    }
+
+    /// <summary>
     /// Returns the srcset attribute value for a saved place image (served via the API).
     /// Returns null for unsaved images that use data URLs so the srcset attribute is omitted entirely.
+    /// When a public share token is provided it is appended to each URL for anonymous access.
     /// </summary>
-    public static string? GetSrcSet(PlaceImage img) =>
+    public static string? GetSrcSet(PlaceImage img, string? publicToken = null) =>
         img.ImageData.Length > 0
             ? null
-            : BuildSrcSet(img.Id);
+            : BuildSrcSet(img.Id, publicToken);
 
     /// <summary>
     /// Returns the srcset attribute value for a place image referenced by its ID.
     /// When a public share token is provided it is appended to each URL for anonymous access.
     /// </summary>
-    public static string BuildSrcSet(string imageId, string? publicToken = null)
-    {
-        var tokenParam = string.IsNullOrWhiteSpace(publicToken) ? string.Empty : $"&token={Uri.EscapeDataString(publicToken)}";
-        return $"/api/placeImages/{imageId}?width=400{tokenParam} 400w, /api/placeImages/{imageId}?width=800{tokenParam} 800w, /api/placeImages/{imageId}?width=1200{tokenParam} 1200w";
-    }
+    public static string BuildSrcSet(string imageId, string? publicToken = null) =>
+        $"{BuildSrc(imageId, 400, publicToken)} 400w, {BuildSrc(imageId, 800, publicToken)} 800w, {BuildSrc(imageId, 1200, publicToken)} 1200w";
 }

--- a/TripPlanner.Web/Components/Shared/PlaceLightbox.razor
+++ b/TripPlanner.Web/Components/Shared/PlaceLightbox.razor
@@ -28,6 +28,9 @@
 @code {
     [Parameter, EditorRequired] public Place Place { get; set; } = null!;
 
+    /// <summary>Public share token for anonymous collection access. When set, appended to image URLs.</summary>
+    [Parameter] public string? PublicToken { get; set; }
+
     /// <summary>Index of the image to show when the lightbox is opened.</summary>
     [Parameter] public int InitialIndex { get; set; }
 
@@ -90,11 +93,12 @@
             return [.. Place.Images
                 .OrderBy(i => i.SortOrder)
                 .Where(img => img.ImageData.Length > 0 || !string.IsNullOrEmpty(img.Id))
-                .Select(img => new ImageEntry(
-                    img.ImageData.Length > 0
-                        ? $"data:{img.ImageContentType};base64,{Convert.ToBase64String(img.ImageData)}"
-                        : $"/api/placeImages/{img.Id}?width=1200",
-                    PlaceImageHelper.GetSrcSet(img)))];
+                .Select(img =>
+                {
+                    if (img.ImageData.Length > 0)
+                        return new ImageEntry($"data:{img.ImageContentType};base64,{Convert.ToBase64String(img.ImageData)}", null);
+                    return new ImageEntry(PlaceImageHelper.BuildSrc(img.Id, 1200, PublicToken), PlaceImageHelper.GetSrcSet(img, PublicToken));
+                })];
         }
 
         // Fall back to ImageIds (API-only, e.g. when loading places without blobs)
@@ -102,8 +106,8 @@
         {
             return [.. Place.ImageIds
                 .Select(id => new ImageEntry(
-                    $"/api/placeImages/{id}?width=1200",
-                    PlaceImageHelper.BuildSrcSet(id)))];
+                    PlaceImageHelper.BuildSrc(id, 1200, PublicToken),
+                    PlaceImageHelper.BuildSrcSet(id, PublicToken)))];
         }
 
         return [];

--- a/TripPlanner.Web/Repositories/PlaceCollectionRepository.cs
+++ b/TripPlanner.Web/Repositories/PlaceCollectionRepository.cs
@@ -4,14 +4,9 @@ using TripPlanner.Web.Models;
 
 namespace TripPlanner.Web.Repositories;
 
-public class PlaceCollectionRepository : IPlaceCollectionRepository
+public class PlaceCollectionRepository(IDbContextFactory<ApplicationDbContext> contextFactory) : IPlaceCollectionRepository
 {
-    private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
-
-    public PlaceCollectionRepository(IDbContextFactory<ApplicationDbContext> contextFactory)
-    {
-        _contextFactory = contextFactory;
-    }
+    private readonly IDbContextFactory<ApplicationDbContext> _contextFactory = contextFactory;
 
     public async Task<List<PlaceCollection>> GetAllByOwnerAsync(string userId)
     {
@@ -29,14 +24,10 @@ public class PlaceCollectionRepository : IPlaceCollectionRepository
 
         foreach (var entry in collectionsWithCounts)
         {
-            entry.Collection.Items = Enumerable.Range(0, entry.ItemCount)
-                .Select(_ => new PlaceCollectionItem())
-                .ToList();
+            entry.Collection.Items = [.. Enumerable.Range(0, entry.ItemCount).Select(_ => new PlaceCollectionItem())];
         }
 
-        return collectionsWithCounts
-            .Select(entry => entry.Collection)
-            .ToList();
+        return [.. collectionsWithCounts.Select(entry => entry.Collection)];
     }
 
     public async Task<PlaceCollection?> GetByIdAsync(string id)
@@ -184,7 +175,7 @@ public class PlaceCollectionRepository : IPlaceCollectionRepository
             .OrderBy(i => i.AddedAt)
             .Select(i => new
             {
-                Place = i.Place,
+                i.Place,
                 GpxTrack = i.Place != null ? i.Place.GpxTrack : null,
                 ImageIds = i.Place != null
                     ? context.PlaceImages

--- a/TripPlanner.Web/Repositories/PlaceCollectionRepository.cs
+++ b/TripPlanner.Web/Repositories/PlaceCollectionRepository.cs
@@ -45,6 +45,7 @@ public class PlaceCollectionRepository : IPlaceCollectionRepository
         return await context.PlaceCollections
             .AsNoTracking()
             .Include(c => c.Items)
+            .ThenInclude(i => i.Place)
             .FirstOrDefaultAsync(c => c.Id == id);
     }
 
@@ -54,6 +55,7 @@ public class PlaceCollectionRepository : IPlaceCollectionRepository
         return await context.PlaceCollections
             .AsNoTracking()
             .Include(c => c.Items)
+            .ThenInclude(i => i.Place)
             .FirstOrDefaultAsync(c => c.PublicShareToken == token);
     }
 


### PR DESCRIPTION
This pull request adds support for sharing public collection map links and anonymous access to collection places and images via a share token. It introduces a "Copy Map Link" button, enables loading map data by public token, and ensures image and GPX URLs are accessible for anonymous users when a token is present. The changes also refactor and extend the handling of image and GPX URLs to append the token as needed.

**Public sharing and anonymous access:**

* Added a "Copy Map Link" button to `CollectionDetailPage.razor`, which copies a public map link containing the collection's share token to the clipboard. [[1]](diffhunk://#diff-508c70097d7c7eda272a362f067b9504373c775cefbae8caa10017bb4afbb97eR47-R49) [[2]](diffhunk://#diff-508c70097d7c7eda272a362f067b9504373c775cefbae8caa10017bb4afbb97eR191-R207)
* The map page (`MapPage.razor`) now accepts a `CollectionToken` query parameter and, when present, loads and displays places from the shared collection for anonymous users. [[1]](diffhunk://#diff-4f584be98ee4f91a087561cd9eae87fc13faedf7fb7257723e62daa9520f3f25R158-R160) [[2]](diffhunk://#diff-4f584be98ee4f91a087561cd9eae87fc13faedf7fb7257723e62daa9520f3f25R272-R273) [[3]](diffhunk://#diff-4f584be98ee4f91a087561cd9eae87fc13faedf7fb7257723e62daa9520f3f25R303-R311)
* The trip selection dropdown is hidden when viewing a shared collection map.

**Image and GPX URL handling for anonymous access:**

* Image and GPX URLs in `MapPlaceCard.razor` and `PlaceLightbox.razor` now append the public token for anonymous access, using new helper methods in `PlaceImageHelper`. [[1]](diffhunk://#diff-96ad9ab55c4d517209f713fc97419583845d7a54d96ff4fdb6aa5c84c43aa43eL22-R22) [[2]](diffhunk://#diff-96ad9ab55c4d517209f713fc97419583845d7a54d96ff4fdb6aa5c84c43aa43eL57-R58) [[3]](diffhunk://#diff-96ad9ab55c4d517209f713fc97419583845d7a54d96ff4fdb6aa5c84c43aa43eL99-R99) [[4]](diffhunk://#diff-96ad9ab55c4d517209f713fc97419583845d7a54d96ff4fdb6aa5c84c43aa43eR137-R139) [[5]](diffhunk://#diff-96ad9ab55c4d517209f713fc97419583845d7a54d96ff4fdb6aa5c84c43aa43eR148-R154) [[6]](diffhunk://#diff-d363390c5768a34c2733915a6246dc12680f11a74db3114cd6599b122e813402R31-R33) [[7]](diffhunk://#diff-d363390c5768a34c2733915a6246dc12680f11a74db3114cd6599b122e813402L93-R110) [[8]](diffhunk://#diff-b8669adb0fec37c84f1ccf99693ff5e6b3bbb49481dda0102145c3c331bfa800R10-R35)
* The public token is passed through to all relevant components to ensure correct resource access. [[1]](diffhunk://#diff-4f584be98ee4f91a087561cd9eae87fc13faedf7fb7257723e62daa9520f3f25L77-R79) [[2]](diffhunk://#diff-4f584be98ee4f91a087561cd9eae87fc13faedf7fb7257723e62daa9520f3f25L96-R99) [[3]](diffhunk://#diff-4f584be98ee4f91a087561cd9eae87fc13faedf7fb7257723e62daa9520f3f25L118-R122) [[4]](diffhunk://#diff-4f584be98ee4f91a087561cd9eae87fc13faedf7fb7257723e62daa9520f3f25L129-R134)

**Repository and data loading improvements:**

* `PlaceCollectionRepository` constructor simplified with primary constructor syntax, and methods updated for conciseness and to ensure related data is eagerly loaded. [[1]](diffhunk://#diff-28070dc53a2df1aeab8b9476e04faa1421b41900e4d6e34c0cec2c58ee4cdf7eL7-R9) [[2]](diffhunk://#diff-28070dc53a2df1aeab8b9476e04faa1421b41900e4d6e34c0cec2c58ee4cdf7eL32-R30) [[3]](diffhunk://#diff-28070dc53a2df1aeab8b9476e04faa1421b41900e4d6e34c0cec2c58ee4cdf7eR39) [[4]](diffhunk://#diff-28070dc53a2df1aeab8b9476e04faa1421b41900e4d6e34c0cec2c58ee4cdf7eR49) [[5]](diffhunk://#diff-28070dc53a2df1aeab8b9476e04faa1421b41900e4d6e34c0cec2c58ee4cdf7eL185-R178)
* `MapPage.razor` injects `IPlaceCollectionRepository` to support loading places by public token.

These changes enable seamless public sharing and anonymous viewing of collection maps, with proper access to images and GPX downloads via a share token.